### PR TITLE
Implement basic screen rotation functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 DEVKIT := docker run -v $$PWD:$$PWD -w $$PWD -it -e LOCAL_IDF_PATH=$$IDF_PATH \
-	  -e LOCAL_IDF_TOOLS_PATH=$${IDF_TOOLS_PATH:-~/.espressif} \
+	  -e LOCAL_IDF_TOOLS_PATH=$${IDF_TOOLS_PATH:-~/.espressif} -e SDKCONFIG_DEFAULTS \
 	  kywy/devkit:latest
 
 .PHONY: license
@@ -12,7 +12,7 @@ license:
 
 .PHONY: flash-server
 flash-server:
-	@if [ -n $$IDF_PORT ]; then \
+	@if [ -z $$IDF_PORT ]; then \
 		echo "IDF_PORT is required but not set"; exit 1; \
 	fi
 	esp_rfc2217_server.py -v -p 4000 $$IDF_PORT

--- a/include/Display.hpp
+++ b/include/Display.hpp
@@ -49,6 +49,8 @@ public:
   esp_err_t clear();
   esp_err_t update();
 
+  esp_err_t setRotation(Rotation rotation);
+
   void printBuffer() { driver->printBuffer(); };
 
   void drawPixel(int16_t x, int16_t y, uint16_t color);
@@ -70,9 +72,9 @@ public:
                 Flags flags = Flags());
   void getTextSize(uint8_t *fontData, char *text, uint16_t &width, uint16_t &height);
 
-private:
   Driver::Driver *driver;
 
+private:
   void drawCircleWithEvenDiameterFromTopLeftCorner(int16_t x, int16_t y, uint16_t diameter, uint16_t color);
   void drawCircleWithOddDiameterFromCenter(int16_t x, int16_t y, uint16_t diameter, uint16_t color);
 

--- a/include/Driver.hpp
+++ b/include/Driver.hpp
@@ -11,6 +11,13 @@
 
 namespace Display {
 
+enum class Rotation {
+  DEFAULT,
+  // CLOCKWISE_90,
+  CLOCKWISE_180,
+  // CLOCKWISE_270,
+};
+
 typedef struct Flags {
   bool transparent = false;
 } Flags;
@@ -56,6 +63,8 @@ public:
   virtual esp_err_t clearBuffer() = 0;
   virtual esp_err_t sendBufferToDisplay() = 0;
 
+  virtual esp_err_t setRotation(Rotation rotation) = 0;
+
   virtual void printBuffer() = 0;
 
   // set a single pixel
@@ -94,7 +103,7 @@ public:
   uint16_t getWidth() { return 64; };
   uint16_t getHeight() { return 64; };
 
-  SERIAL_64X64_DRIVER(){};
+  SERIAL_64X64_DRIVER() : Driver{PinMap()} {};
   SERIAL_64X64_DRIVER(PinMap pins) : Driver{pins} {};
 
   esp_err_t sendCommands(uint8_t *commands, uint8_t bytes);
@@ -103,6 +112,8 @@ public:
   esp_err_t clearBuffer();
   esp_err_t sendBufferToDisplay();
 
+  esp_err_t setRotation(Rotation rotation);
+
   void printBuffer();
 
   void setBufferPixel(int16_t x, int16_t y, uint16_t color);
@@ -110,6 +121,9 @@ public:
 
   void writeBitmapToBuffer(int16_t x, int16_t y, uint16_t width, uint16_t height, void *bitmap,
                            Bitmap::BitmapFormat format, uint16_t color, Flags flags = Flags());
+
+private:
+  Rotation rotation = Rotation::DEFAULT;
 };
 
 #ifndef CONFIG_IDF_TARGET_LINUX
@@ -127,6 +141,8 @@ public:
   esp_err_t initializeDisplay();
   esp_err_t clearBuffer();
   esp_err_t sendBufferToDisplay();
+
+  esp_err_t setRotation(Rotation rotation);
 
   void printBuffer();
 

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -12,6 +12,8 @@ esp_err_t Display::clear() { return driver->clearBuffer(); }
 
 esp_err_t Display::update() { return driver->sendBufferToDisplay(); }
 
+esp_err_t Display::setRotation(Rotation rotation) { return driver->setRotation(rotation); }
+
 void Display::drawPixel(int16_t x, int16_t y, uint16_t color) { driver->setBufferPixel(x, y, color); }
 
 void Display::shiftOrigin2DToTopLeft(Origin::Object2D origin, int16_t &x, int16_t &y, uint16_t width, uint16_t height) {

--- a/src/drivers/SSD1327_128X128_SPI_DRIVER.cpp
+++ b/src/drivers/SSD1327_128X128_SPI_DRIVER.cpp
@@ -205,6 +205,22 @@ esp_err_t SSD1327_128X128_SPI_DRIVER::sendBufferToDisplay() {
   return ESP_OK;
 }
 
+esp_err_t SSD1327_128X128_SPI_DRIVER::setRotation(Display::Rotation rotation) {
+  switch (rotation) {
+  case Rotation::DEFAULT: {
+    uint8_t rotateDisplay[] = {0xa0, 0b01000010};
+    return sendCommands(rotateDisplay, sizeof(rotateDisplay));
+    break;
+  }
+  case Rotation::CLOCKWISE_180: {
+    uint8_t rotateDisplay[] = {0xa0, 0b01010001};
+    return sendCommands(rotateDisplay, sizeof(rotateDisplay));
+    break;
+  }
+  }
+  return ESP_OK;
+}
+
 void SSD1327_128X128_SPI_DRIVER::setBufferPixel(int16_t x, int16_t y, uint16_t color) {
   if (x < 0 || x >= 128 || y < 0 || y >= 128) {
     return;


### PR DESCRIPTION
This commit allows users to rotate the screen 180 degrees. 90 degree rotations are not yet supported as they cannot be performed as easily. A 180 degree rotation can be done with a simple memory remap.

For the SSD1327 driver this is done by setting the GDDRAM configurations and for the serial driver we just change the order that bytes are read from the buffer.